### PR TITLE
add bucket policy for writing logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,35 @@
+data "aws_elb_service_account" "default" {}
+
+#------------------------------------------------------------------------------
+# IAM POLICY DOCUMENT - For access logs to the s3 bucket
+#------------------------------------------------------------------------------
+data "aws_iam_policy_document" "lb_logs_access_policy_document" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_elb_service_account.default.arn]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.name_prefix}-lb-logs/*",
+    ]
+  }
+}
+
+#------------------------------------------------------------------------------
+# IAM POLICY - For access logs to the s3 bucket
+#------------------------------------------------------------------------------
+resource "aws_s3_bucket_policy" "lb_logs_access_policy" {
+  bucket = aws_s3_bucket.logs.id
+  policy = data.aws_iam_policy_document.lb_logs_access_policy_document.json
+}
+
 #------------------------------------------------------------------------------
 # S3 BUCKET - For access logs
 #------------------------------------------------------------------------------


### PR DESCRIPTION
hi @jnonino I was receiving the following error creating the lb:
```
module.sonarqube.module.ecs_fargate.module.ecs-fargate-service.module.ecs-alb.aws_lb.lb: Still creating... [30s elapsed]

Error: Failure configuring LB attributes: InvalidConfigurationRequest: Access Denied for bucket: fnx-sonar-lb-logs. Please check S3bucket permission
        status code: 400, request id: 069b9db6-dee3-45b8-b760-b9243b1d5466


Releasing state lock. This may take a few moments...
```

I'm thinking it's because it didn't have a policy to allow the LB to write logs? 
I put in an attempt at fixing it. Using these changes, I was able to progress in the load balancer creation however, I ran into a different error later on which I am still debugging and will create an issue for. 