### PR TITLE
Add S3 bucket public access block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,20 @@ resource "aws_s3_bucket_policy" "lb_logs_access_policy" {
 }
 
 #------------------------------------------------------------------------------
+# S3 bucket block public access
+#------------------------------------------------------------------------------
+resource "aws_s3_bucket_public_access_block" "lb_logs_block_public_access" {
+  count = var.block_s3_bucket_public_access ? 1 : 0
+
+  bucket = aws_s3_bucket.logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+#------------------------------------------------------------------------------
 # APPLICATION LOAD BALANCER
 #------------------------------------------------------------------------------
 resource "aws_lb" "lb" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,15 @@ variable "vpc_id" {
 }
 
 #------------------------------------------------------------------------------
+# S3 bucket
+#------------------------------------------------------------------------------
+variable "block_s3_bucket_public_access" {
+  description = "(Optional) If true, public access to the S3 bucket will be blocked."
+  type        = bool
+  default     = false
+}
+
+#------------------------------------------------------------------------------
 # APPLICATION LOAD BALANCER
 #------------------------------------------------------------------------------
 variable "internal" {
@@ -78,7 +87,7 @@ variable "ip_address_type" {
 #------------------------------------------------------------------------------
 variable "http_ports" {
   description = "Map containing objects with two fields, listener_port and the target_group_port to redirect HTTP requests"
-  type        = map
+  type        = map(any)
   default = {
     default_http = {
       listener_port     = 80
@@ -89,7 +98,7 @@ variable "http_ports" {
 
 variable "https_ports" {
   description = "Map containing objects with two fields, listener_port and the target_group_port to redirect HTTPS requests"
-  type        = map
+  type        = map(any)
   default = {
     default_http = {
       listener_port     = 443
@@ -213,6 +222,6 @@ variable "default_certificate_arn" {
 
 variable "additional_certificates_arn_for_https_listeners" {
   description = "(Optional) List of SSL server certificate ARNs for HTTPS listener. Use it if you need to set additional certificates besides default_certificate_arn"
-  type        = list
+  type        = list(any)
   default     = []
 }


### PR DESCRIPTION
Following best practices, it is recommended to block public access to the S3 bucket.

Since this is a bucket for storing ALB logs I think it makes sense to have this option, however, to make this change not that disruptive I didn't enable it by default (Let me know if you think I should enable it, but wanted to make this change as less disruptive as possible).

Thanks!