### PR TITLE
Extend lb_listener types to support redirect and fixed-response

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,46 @@ variable "http_ports" {
   }
 }
 
+/*
+
+Other options for listeners (The same are valid also for https_ports variable):
+
+Redirect (Force HTTPS):
+
+variable "http_ports" {
+  description = "Map containing objects with two fields, listener_port and the target_group_port to redirect HTTP requests"
+  type        = map
+  default = {
+    force_https = {
+      type          = "redirect"
+      listener_port = 80
+      host          = "#{host}"
+      path          = "/#{path}"
+      port          = "443"
+      protocol      = "https"
+      query         = "#{query}"
+      status_code   = "HTTP_301"
+    }
+  }
+}
+
+variable "http_ports" {
+  description = "Map containing objects with two fields, listener_port and the target_group_port to redirect HTTP requests"
+  type        = map
+  default = {
+    fixed_response = {
+      type          = "fixed-response"
+      listener_port = 80
+      content_type  = "text/plain"
+      message_body  = "Server error"
+      status_code   = "500"
+    }
+  }
+}
+
+*/
+
+
 variable "https_ports" {
   description = "Map containing objects with two fields, listener_port and the target_group_port to redirect HTTPS requests"
   type        = map(any)


### PR DESCRIPTION
Currently, the module only supports the `forward` type for `aws_lb_listener`.

In my use-case, I need to do a redirect from HTTP to HTTPS.

This PR should allow users to:

- Create their own redirect rules by leveraging the `redirect` `aws_lb_listener` type.
- Create `fixed-response` `aws_lb_listener ` type.

I tried to make this backward compatible, so if `http_ports` or `https_ports` variables are kept the same way they are now (Without `type`) it should not change anything.

I have tested this on my own, but another pair of eyes are more than welcome.

Thanks!