### PR TITLE
feat: Allow to configure the protocol of the target group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -143,7 +143,7 @@ resource "aws_lb_target_group" "lb_http_tgs" {
   }
   name                          = "${var.name_prefix}-http-${each.value.target_group_port}"
   port                          = each.value.target_group_port
-  protocol                      = "HTTP"
+  protocol                      = lookup(each.value, "target_group_protocol", "") == "" ?  "HTTP" : each.value.target_group_protocol
   vpc_id                        = var.vpc_id
   deregistration_delay          = var.deregistration_delay
   slow_start                    = var.slow_start
@@ -160,7 +160,7 @@ resource "aws_lb_target_group" "lb_http_tgs" {
     enabled             = var.target_group_health_check_enabled
     interval            = var.target_group_health_check_interval
     path                = var.target_group_health_check_path
-    protocol            = "HTTP"
+    protocol            = lookup(each.value, "target_group_protocol", "") == "" ?  "HTTP" : each.value.target_group_protocol
     timeout             = var.target_group_health_check_timeout
     healthy_threshold   = var.target_group_health_check_healthy_threshold
     unhealthy_threshold = var.target_group_health_check_unhealthy_threshold
@@ -186,7 +186,7 @@ resource "aws_lb_target_group" "lb_https_tgs" {
   }
   name                          = "${var.name_prefix}-https-${each.value.target_group_port}"
   port                          = each.value.target_group_port
-  protocol                      = "HTTPS"
+  protocol                      = lookup(each.value, "target_group_protocol", "") == "" ?  "HTTPS" : each.value.target_group_protocol
   vpc_id                        = var.vpc_id
   deregistration_delay          = var.deregistration_delay
   slow_start                    = var.slow_start
@@ -203,7 +203,7 @@ resource "aws_lb_target_group" "lb_https_tgs" {
     enabled             = var.target_group_health_check_enabled
     interval            = var.target_group_health_check_interval
     path                = var.target_group_health_check_path
-    protocol            = "HTTPS"
+    protocol            = lookup(each.value, "target_group_protocol", "") == "" ?  "HTTPS" : each.value.target_group_protocol
     timeout             = var.target_group_health_check_timeout
     healthy_threshold   = var.target_group_health_check_healthy_threshold
     unhealthy_threshold = var.target_group_health_check_unhealthy_threshold

--- a/variables.tf
+++ b/variables.tf
@@ -118,10 +118,9 @@ variable "https_ports" {
 /*
 Other options for listeners (The same are valid also for https_ports variable):
 
-Redirect (Force HTTPS):
   variable "http_ports" {
-    description = "Map containing objects with two fields, listener_port and the target_group_port to redirect HTTP requests"
-    type        = map
+    description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
+    type        = map(any)
     default = {
       force_https = {
         type          = "redirect"
@@ -135,10 +134,11 @@ Redirect (Force HTTPS):
       }
     }
   }
+
 Fixed response:
   variable "http_ports" {
-    description = "Map containing objects with two fields, listener_port and the target_group_port to redirect HTTP requests"
-    type        = map
+    description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
+    type        = map(any)
     default = {
       fixed_response = {
         type          = "fixed-response"
@@ -149,6 +149,22 @@ Fixed response:
       }
     }
   }
+
+Additionally, you can have an HTTPS listener forwarding traffic to an HTTP target group by setting `target_group_protocol` to `HTTP`. The default for `https_ports` variable is `HTTPS`:
+
+  variable "https_ports" {
+    description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
+    type        = map(any)
+    default = {
+      https_listener_to_http_target_group = {
+        type                  = "forward"
+        listener_port         = 443
+        target_group_port     = 80
+        target_group_protocol = HTTP
+      }
+    }
+  }
+
 */
 
 variable "http_ingress_cidr_blocks" {


### PR DESCRIPTION
Hi @jnonino 👋 ,

I did #6 back in 2020 and never pushed a PR for this feature that we have been using privately.

Basically when you have an HTTPS listener that forwards traffic to an HTTP port, the target group protocol as well as its health check needs to be HTTP (Otherwise the target group will mark the target as unhealthy and will not forward traffic).

Once this is merged I can push a PR for [terraform-aws-ecs-fargate-service](https://github.com/cn-terraform/terraform-aws-ecs-fargate-service) to document this functionality.

Thanks!