### PR TITLE
fix: Fix random race-condition in bucket policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,8 @@ resource "aws_s3_bucket_public_access_block" "lb_logs_block_public_access" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+
+  depends_on = [aws_s3_bucket_policy.lb_logs_access_policy]
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
There are cases when `block_s3_bucket_public_access`
variable is `true` and Terraform tries to apply both policies at same
time:

- `aws_s3_bucket_policy.lb_logs_access_policy`
- `aws_s3_bucket_public_access_block.lb_logs_block_public_access`