### PR TITLE
Enable Sever Side Encryption for S3 bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,19 @@ resource "aws_s3_bucket_acl" "logs" {
   acl    = "log-delivery-write"
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  count = var.enable_s3_bucket_server_side_encryption ? 1 : 0
+
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.s3_bucket_server_side_encryption_key_arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
 #------------------------------------------------------------------------------
 # IAM POLICY DOCUMENT - For access logs to the S3 bucket
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,18 @@ variable "block_s3_bucket_public_access" {
   default     = false
 }
 
+variable "aws_s3_bucket_server_side_encryption_configuration" {
+  description = "(Optional) If true, server side encryption will be applied."
+  type        = bool
+  default     = false
+}
+
+variable "s3_bucket_server_side_encryption_key_arn" {
+  description = "(Optional) Allows the SSE key to use a Customer Managed Key, defaults to the alias and AWS managed key."
+  type        = string
+  default     = "aws/s3"
+}
+
 #------------------------------------------------------------------------------
 # APPLICATION LOAD BALANCER
 #------------------------------------------------------------------------------


### PR DESCRIPTION
* For the use case of conforming to AWS Security Best practices
* Allows for S3 Bucket server side encryption