### PR TITLE
S3 Bucket server side encryption depends on ALB to be created first

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
       sse_algorithm     = "aws:kms"
     }
   }
+
+  depends_on = [aws_lb.lb]
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
* The S3 Bucket server side encryption configuration resource requires the ALB to be created first, adds a depends on `alb.lb`