### PR TITLE
Adds key to TG name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,9 +120,9 @@ resource "aws_lb_target_group" "lb_http_tgs" {
     for name, config in var.http_ports : name => config
     if lookup(config, "type", "") == "" || lookup(config, "type", "") == "forward"
   }
-  name                          = "${var.name_prefix}-http-${each.value.target_group_port}"
+  name                          = "${var.name_prefix}-${each.key}-http-${each.value.target_group_port}"
   port                          = each.value.target_group_port
-  protocol                      = lookup(each.value, "target_group_protocol", "") == "" ? "HTTP" : each.value.target_group_protocol
+  protocol                      = lookup(each.value, "target_group_protocol", "HTTP")
   vpc_id                        = var.vpc_id
   deregistration_delay          = var.deregistration_delay
   slow_start                    = var.slow_start
@@ -139,7 +139,7 @@ resource "aws_lb_target_group" "lb_http_tgs" {
     enabled             = var.target_group_health_check_enabled
     interval            = var.target_group_health_check_interval
     path                = var.target_group_health_check_path
-    protocol            = lookup(each.value, "target_group_protocol", "") == "" ? "HTTP" : each.value.target_group_protocol
+    protocol            = lookup(each.value, "target_group_protocol", "HTTP")
     timeout             = var.target_group_health_check_timeout
     healthy_threshold   = var.target_group_health_check_healthy_threshold
     unhealthy_threshold = var.target_group_health_check_unhealthy_threshold
@@ -149,7 +149,7 @@ resource "aws_lb_target_group" "lb_http_tgs" {
   tags = merge(
     var.tags,
     {
-      Name = "${var.name_prefix}-http-${each.value.target_group_port}"
+      Name = "${var.name_prefix}-${each.key}-http-${each.value.target_group_port}"
     },
   )
   lifecycle {
@@ -163,9 +163,9 @@ resource "aws_lb_target_group" "lb_https_tgs" {
     for name, config in var.https_ports : name => config
     if lookup(config, "type", "") == "" || lookup(config, "type", "") == "forward"
   }
-  name                          = "${var.name_prefix}-https-${each.value.target_group_port}"
+  name                          = "${var.name_prefix}-${each.key}-https-${each.value.target_group_port}"
   port                          = each.value.target_group_port
-  protocol                      = lookup(each.value, "target_group_protocol", "") == "" ? "HTTPS" : each.value.target_group_protocol
+  protocol                      = lookup(each.value, "target_group_protocol", "HTTPS")
   vpc_id                        = var.vpc_id
   deregistration_delay          = var.deregistration_delay
   slow_start                    = var.slow_start
@@ -182,7 +182,7 @@ resource "aws_lb_target_group" "lb_https_tgs" {
     enabled             = var.target_group_health_check_enabled
     interval            = var.target_group_health_check_interval
     path                = var.target_group_health_check_path
-    protocol            = lookup(each.value, "target_group_protocol", "") == "" ? "HTTPS" : each.value.target_group_protocol
+    protocol            = lookup(each.value, "target_group_protocol", "HTTPS")
     timeout             = var.target_group_health_check_timeout
     healthy_threshold   = var.target_group_health_check_healthy_threshold
     unhealthy_threshold = var.target_group_health_check_unhealthy_threshold
@@ -192,7 +192,7 @@ resource "aws_lb_target_group" "lb_https_tgs" {
   tags = merge(
     var.tags,
     {
-      Name = "${var.name_prefix}-https-${each.value.target_group_port}"
+      Name = "${var.name_prefix}-${each.key}-https-${each.value.target_group_port}"
     },
   )
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "http_ports" {
   description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
   type        = map(any)
   default = {
-    default_http = {
+    default = {
       type              = "forward"
       listener_port     = 80
       target_group_port = 80
@@ -155,7 +155,7 @@ variable "https_ports" {
   description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
   type        = map(any)
   default = {
-    default_http = {
+    default = {
       type              = "forward"
       listener_port     = 443
       target_group_port = 443
@@ -170,7 +170,7 @@ Other options for listeners (The same are valid also for https_ports variable):
     description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
     type        = map(any)
     default = {
-      force_https = {
+      force-https = {
         type          = "redirect"
         listener_port = 80
         host          = "#{host}"
@@ -188,7 +188,7 @@ Fixed response:
     description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
     type        = map(any)
     default = {
-      fixed_response = {
+      fixed-response = {
         type          = "fixed-response"
         listener_port = 80
         content_type  = "text/plain"
@@ -204,7 +204,7 @@ Additionally, you can have an HTTPS listener forwarding traffic to an HTTP targe
     description = "Map containing objects to define listeners behaviour based on type field. If type field is `forward`, include listener_port and the target_group_port. For `redirect` type, include listener port, host, path, port, protocol, query and status_code. For `fixed-response`, include listener_port, content_type, message_body and status_code"
     type        = map(any)
     default = {
-      https_listener_to_http_target_group = {
+      https-to-http-tg = {
         type                  = "forward"
         listener_port         = 443
         target_group_port     = 80


### PR DESCRIPTION
The purpose of this is to address an issue encountered when trying to configure an ELB for Blue/Green deployment configuration.

AWS CodeDeploy developer documentation describes this scenario in more detail. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-bluegreen.html

When attempting to configure a Fargate application using `cn-terraform/ecs-fargate/aws` module, the target_groups are configured as:
```
  lb_http_ports       = {
    blue = {
      listener_port     = local.production_port
      target_group_port = local.target_port
    },
    green = {
      listener_port     = local.target_port
      target_group_port = local.target_port
    }
  }
```

With the current naming scheme, it results in the `terraform-aws-ecs-alb` module throwing an error attempting to create two TGs with the same name. The only fix is to make the target_group names unique. The `name` property was being extract in the for loop, but was never used. This change simply uses the property value that was already available and it gives implementors more control over TG names.