### PR TITLE
Fix additional certificates usage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -303,8 +303,8 @@ resource "aws_lb_listener" "lb_https_listeners" {
 locals {
   list_maps_listener_certificate_arns = flatten([
     for cert_arn in var.additional_certificates_arn_for_https_listeners : [
-      for listener in aws_lb_listener.lb_https_listeners : {
-        name            = "${listener}-${cert_arn}"
+      for index, listener in aws_lb_listener.lb_https_listeners : {
+        name            = "listener-${index}-${listener.protocol}-${listener.port}"
         listener_arn    = listener.arn
         certificate_arn = cert_arn
       }


### PR DESCRIPTION
Hey @jnonino 👋 ,

I'm trying to use an additional ACM certificate in [cn-terraform/terraform-aws-ecs-fargate-service](https://github.com/cn-terraform/terraform-aws-ecs-fargate-service) but it is not working because `${listener}` is an object:

```
╷
│ Error: Invalid template interpolation value
│ 
│   on .terraform/modules/ecs_traefik_external_service.ecs-alb/main.tf line 307, in locals:
│  307:         name            = "${listener}-${cert_arn}"
│ 
│ Cannot include the given value in a string template: string required.
```

And `${cert_arn}` cannot be used could be not defined (e.g I'm using a [module](https://github.com/terraform-aws-modules/terraform-aws-acm) to generate it):

```
╷
│ Error: Invalid for_each argument
│ 
│   on .terraform/modules/ecs_traefik_external_service.ecs-alb/main.tf line 323, in resource "aws_lb_listener_certificate" "additional_certificates_for_https_listeners":
│  323:   for_each        = local.map_listener_certificate_arns
│     ├────────────────
│     │ local.map_listener_certificate_arns will be known only after apply
│ 
│ The "for_each" map includes keys derived from resource attributes that
│ cannot be determined until apply, and so Terraform cannot determine the
│ full set of keys that will identify the instances of this resource.
│ 
│ When working with unknown values in for_each, it's better to define the map
│ keys statically in your configuration and place apply-time results only in
│ the map values.
│ 
│ Alternatively, you could use the -target planning option to first apply
│ only the resources that the for_each value depends on, and then apply a
│ second time to fully converge.
```

With this change Terraform plan succeeds and this is what I see now:

```
  # module.ecs_traefik_external_service.module.ecs-alb[0].aws_lb_listener_certificate.additional_certificates_for_https_listeners["listener-tg-HTTPS-443"] will be crea
ted                                                                                                                                                                    
  + resource "aws_lb_listener_certificate" "additional_certificates_for_https_listeners" {                                                                             
      + certificate_arn = (known after apply)                                                                                                                          
      + id              = (known after apply)                                                                                                                          
      + listener_arn    = (known after apply)                                                                                                                          
    }
```

In case you accept this PR can you please do a new release of this module as well as `cn-terraform/terraform-aws-ecs-fargate-service` please 🙏 ?

Thank you very much!