### PR TITLE
Add missing health check port configuration for HTTPS target groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In order to run all checks at any point run the following command:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.92.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.93.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
 
 ## Modules

--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,7 @@ resource "aws_lb_target_group" "lb_https_tgs" {
     enabled             = var.target_group_health_check_enabled
     interval            = var.target_group_health_check_interval
     path                = var.target_group_health_check_path
+    port                = var.target_group_health_check_port
     protocol            = lookup(each.value, "target_group_protocol", "HTTP")
     timeout             = var.target_group_health_check_timeout
     healthy_threshold   = var.target_group_health_check_healthy_threshold


### PR DESCRIPTION
Added the `port` attribute to the health check configuration for the target group to ensure proper functionality. Updated the README provider versions to reflect accurate compatibility and requirements.